### PR TITLE
Introducing ability to override the default java memory allocation pool through new javaOptions argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 Installation can be done using [Visual Studio MarketPlace](https://marketplace.visualstudio.com/items?itemName=JoshKnutsonExtensions.devops-extension-cflint).
 
-***Java must be installed on the maching at this time**
+***Java must be installed on the machine at this time**
 
 ## Source Code
 
@@ -39,6 +39,7 @@ Add the task to your build configuration:
 - task: cflint@1
   inputs:
     workingFolder: '' #starting folder to start scanning
+    javaOptions: '' #override default java memory allocation pool of -Xmx512m and add other java options
     cflintJarDownloadUrl: 'https://github.com/cflint/CFLint/releases/download/CFLint-1.5.0/CFLint-1.5.0-all.jar'
     cflintarguments: '' #extra arguments you want to pass along
 ```
@@ -46,6 +47,7 @@ Add the task to your build configuration:
 Arguments have to be specified:
 
 * By default the cfLint is running in the root of the repository, you can modify that in the advanced settings as the working folder task parameter.
+* by default the cfLint jar is provided a default java memory allocation pool of -Xmx512m, you can modify that in the advanced settings as the javaOptions task parameter.
 * By default the cfLint jar is downloaded from the url: `https://github.com/cflint/CFLint/releases/download/CFLint-1.5.0/CFLint-1.5.0-all.jar`:
   * You can change overwrite it to a different version if needed
   * But now file shares and local files are supported to such as:

--- a/tasks/cflint.js
+++ b/tasks/cflint.js
@@ -4,16 +4,19 @@ var child_process = require("child_process");
 var process = require("process");
 var path = require("path");
 var fs = require("fs");
-var executeCflintJar = function (taskDisplayName, cflintJarArguments) {
+var executeCflintJar = function (taskDisplayName, javaOptions, cflintJarArguments) {
     var workingFolder = process.cwd();
     var outputDirectory = workingFolder;
     //const outputDirectory = path.resolve(workingFolder, "cflint/output");
     //!fs.existsSync(outputDirectory) && fs.mkdirSync(outputDirectory);
     //const outputHTMLFileName = ${path.resolve(outputDirectory, outputFileName+'.html')};
+    if (javaOptions === undefined) {
+        javaOptions = "-Xmx512m";
+    }
     if (cflintJarArguments === undefined) {
         cflintJarArguments = "";
     }
-    var commandToExecute = "java -Xmx512m -jar ".concat(path.resolve(workingFolder, "cflint.jar"), " ").concat(cflintJarArguments, " -folder ").concat(workingFolder, "  -html -htmlfile ").concat(path.resolve(outputDirectory, "coverage.html"), " -text -textfile ").concat(path.resolve(outputDirectory, "coverage.txt"), " -json -jsonfile ").concat(path.resolve(outputDirectory, "coverage.json"));
+    var commandToExecute = "java ".concat(javaOptions, " -jar ").concat(path.resolve(workingFolder, "cflint.jar"), " ").concat(cflintJarArguments, " -folder ").concat(workingFolder, "  -html -htmlfile ").concat(path.resolve(outputDirectory, "coverage.html"), " -text -textfile ").concat(path.resolve(outputDirectory, "coverage.txt"), " -json -jsonfile ").concat(path.resolve(outputDirectory, "coverage.json"));
     console.log('Run Code Analysis');
     console.log("Executing command: ".concat(commandToExecute));
     child_process.exec(commandToExecute, function (error, stdout) {

--- a/tasks/cflint.ts
+++ b/tasks/cflint.ts
@@ -3,16 +3,19 @@ import * as process from "process";
 import * as path from "path";
 import * as fs from "fs";
 
-const executeCflintJar = (taskDisplayName: string, cflintJarArguments: string) => {
+const executeCflintJar = (taskDisplayName: string, javaOptions: string, cflintJarArguments: string) => {
     const workingFolder = process.cwd();
     const outputDirectory = workingFolder;
     //const outputDirectory = path.resolve(workingFolder, "cflint/output");
     //!fs.existsSync(outputDirectory) && fs.mkdirSync(outputDirectory);
     //const outputHTMLFileName = ${path.resolve(outputDirectory, outputFileName+'.html')};
+    if(javaOptions === undefined) {
+        javaOptions = "-Xmx512m";
+    }
     if(cflintJarArguments === undefined) {
         cflintJarArguments = "";
     }
-    const commandToExecute = `java -Xmx512m -jar ${path.resolve(workingFolder, "cflint.jar")} ${cflintJarArguments} -folder ${workingFolder}  -html -htmlfile ${path.resolve(outputDirectory, "coverage.html")} -text -textfile ${path.resolve(outputDirectory, "coverage.txt")} -json -jsonfile ${path.resolve(outputDirectory, "coverage.json")}`;
+    const commandToExecute = `java ${javaOptions} -jar ${path.resolve(workingFolder, "cflint.jar")} ${cflintJarArguments} -folder ${workingFolder}  -html -htmlfile ${path.resolve(outputDirectory, "coverage.html")} -text -textfile ${path.resolve(outputDirectory, "coverage.txt")} -json -jsonfile ${path.resolve(outputDirectory, "coverage.json")}`;
     console.log('Run Code Analysis');
     console.log(`Executing command: ${commandToExecute}`);
 

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -41,7 +41,7 @@ var cflintDownloader_1 = require("./cflintDownloader");
 var cflint_1 = require("./cflint");
 function run() {
     return __awaiter(this, void 0, void 0, function () {
-        var taskDisplayName, workingFolder, cflintJarDownloadUrl, cflintArguments;
+        var taskDisplayName, workingFolder, javaOptions, cflintJarDownloadUrl, cflintArguments;
         return __generator(this, function (_a) {
             taskDisplayName = tl.getVariable("task.displayname");
             if (!taskDisplayName) {
@@ -55,6 +55,11 @@ function run() {
             console.log("working folder: ".concat(workingFolder));
             tl.cd(workingFolder);
             process.chdir(workingFolder);
+            javaOptions = tl.getInput("javaOptions");
+            if (javaOptions === undefined || javaOptions === '') {
+                javaOptions = "";
+            }
+            console.log("arguments: ".concat(javaOptions));
             cflintJarDownloadUrl = tl.getInput("cflintJarDownloadUrl", true);
             console.log("cflint-jar download url: ".concat(cflintJarDownloadUrl));
             cflintArguments = tl.getInput("cflintArguments");
@@ -67,7 +72,7 @@ function run() {
                     if (error) {
                         throw error;
                     }
-                    (0, cflint_1.default)(taskDisplayName, cflintArguments);
+                    (0, cflint_1.default)(taskDisplayName, javaOptions, cflintArguments);
                 });
             }
             catch (err) {

--- a/tasks/index.ts
+++ b/tasks/index.ts
@@ -21,6 +21,12 @@ async function run (): Promise<void> {
 
     tl.cd(workingFolder);
     process.chdir(workingFolder);
+    
+    var javaOptions = tl.getInput("javaOptions");
+    if (javaOptions === undefined || javaOptions === '') {
+        javaOptions = "";
+    }
+    console.log(`arguments: ${javaOptions}`);
 
     const cflintJarDownloadUrl = tl.getInput("cflintJarDownloadUrl", true);
     console.log(`cflint-jar download url: ${cflintJarDownloadUrl}`);
@@ -39,7 +45,7 @@ async function run (): Promise<void> {
                     throw error;
                 }
 
-                executeCflint(taskDisplayName, cflintArguments);
+                executeCflint(taskDisplayName, javaOptions, cflintArguments);
             });
     } catch (err) {
         tl.setResult(tl.TaskResult.Failed, `${taskDisplayName} failed`);

--- a/tasks/package-lock.json
+++ b/tasks/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "@types/node": "^22.13.1",
-        "@types/q": "^1.5.8"
+        "@types/q": "^1.5.8",
+        "typescript": "^5.9.3"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -112,9 +113,10 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1282,6 +1284,20 @@
       "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
       "dependencies": {
         "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/unbzip2-stream": {

--- a/tasks/package.json
+++ b/tasks/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.13.1",
-    "@types/q": "^1.5.8"
+    "@types/q": "^1.5.8",
+    "typescript": "^5.9.3"
   }
 }

--- a/tasks/task.json
+++ b/tasks/task.json
@@ -2,8 +2,8 @@
     "$schema": "https://raw.githubusercontent.com/Microsoft/azure-pipelines-task-lib/master/tasks.schema.json",
     "id": "b4d2dbe4-ed52-47a2-824d-50bedb38fbf1",
     "name": "cflint",
-    "friendlyName": "Static code analysis for CFML (a linter) for builds",
-    "description": "This extension uses the CFLint tool to scan CFML files and provide feedback on potential issues. The linter optionally takes rule configuration via a `.cflintrc` file.",
+    "friendlyName": "Static code analysis for CFML for builds",
+    "description": "This extension uses the cfLint tool to scan CFML files and provide feedback on potential issues. The linter optionally takes rule configuration via a `.cflintrc` file.",
     "author": "Josh Knutson",
     "helpMarkDown": "[More information](https://marketplace.visualstudio.com/items?itemName=joshknutsonextensions.devops-extension-cflint) [**CFLint** configuration](https://github.com/cflint/CFLint#folder-based-configuration)",
     "category": "Build",
@@ -18,7 +18,7 @@
     "version": {
         "Major": 1,
         "Minor": 3,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [
@@ -66,7 +66,7 @@
         }
     ],
     "execution": {
-        "Node": {
+        "Node20_1": {
             "target": "index.js"
         }
     }

--- a/tasks/task.json
+++ b/tasks/task.json
@@ -40,6 +40,14 @@
             "groupName": "advanced"
         },
         {
+            "name": "javaOptions",
+            "type": "string",
+            "label": "javaOptions",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "JAVA Options for the cflint jar, this will override the default java memory allocation pool of -Xmx512m."
+        },
+        {
             "name": "cflintJarDownloadUrl",
             "type": "string",
             "label": "Download url of cflint-jar",

--- a/tasks/task.json
+++ b/tasks/task.json
@@ -18,7 +18,7 @@
     "version": {
         "Major": 1,
         "Minor": 3,
-        "Patch": 0
+        "Patch": 1
     },
     "minimumAgentVersion": "1.95.0",
     "groups": [

--- a/tasks/tsconfig.json
+++ b/tasks/tsconfig.json
@@ -1,11 +1,13 @@
 {
     "exclude": [
         "node_modules",
+        "../node_modules"
     ],
     "compilerOptions": {
       "target": "es5",
       "module": "commonjs",
-      "sourceMap": false
+      "sourceMap": false,
+      "skipLibCheck": true
     },
     "files": [
         "cflint.ts",

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -2,7 +2,7 @@
  	"manifestVersion": 1,
  	"id": "devops-extension-cflint",
  	"publisher": "JoshKnutsonExtensions",
- 	"version": "1.3.0",
+ 	"version": "1.3.1",
  	"name": "cflint code analysis",
  	"description": "Run cflint Static code analysis for CFML (a linter) as part of your build",
  	"public": true,


### PR DESCRIPTION
## What Changed
* Introduced the ability to override the default java memory allocation pool through a new `javaOptions` argument
* Upgraded task runner dependency that is end-of-life and will be removed in the future. 
* Reduced `friendlyName` to meet the requirement of being <= 40 chars


## Why Are We Doing This
Due to the substantial size of our application and its files we have found that the default java memory allocation pool of `-Xmx512m` is insufficient. To resolve this we have introduced the ability to override the default memory application pool through a new `javaOptions` argument.
